### PR TITLE
Adds section on GDPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,52 @@ please see: https://github.com/dwyl/ISO-27001-2013-information-technology-securi
 The General Data Protection Regulation (GDPR) is the new EU data protection
 framework that will take over from the UK Data Protection Act 1998 as of
 25th May 2018, for any organisations operating in or offering goods/services to
-the EU.
+individuals in the EU.
 
 > [For the UK] The government has confirmed that the UK’s decision to leave the EU will not affect the commencement of the GDPR.
 
 We have read through these and pulled out information _relevant to the kind of
-work that we do at dwyl_ but please see the [Recommended Reading](#recommended-reading)
-section below for resources with further details which may pertain to you.
+work that we do at dwyl_ and focus mostly on changes from DPA,
+but please see the [Recommended Reading](#recommended-reading)
+section below for resources with further details which may pertain to you and
+are not included here.
+
+#### Key Points
++ You must have a **lawful basis** to process personal data
+  + The most common one here might be ` 6(1)(a) – Consent of the data subject`,
+  but a list can be found at https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/key-areas-to-consider
++ **Consent**
+  + Must be **opt-in** ("consent cannot be inferred from silence, pre-ticked boxes or inactivity")
+  + Must be _separate_ from other Terms & Conditions
+  + Must provide simple ways for consent to be withdrawn
+  + No need to seek new consent from existing users _but_ "if you rely on
+  individuals’ consent to process their data, make sure it will meet the GDPR
+  standard on being specific, granular, clear, prominent, opt-in, properly
+  documented and easily withdrawn"
++ For services offered _directly_ to children, additional measures of protection
+for children's personal data will be put in place (see 'Children's Personal Data'
+section on this page: https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/key-areas-to-consider)
++ ***Actions*** around **individuals' rights**; individuals must:
+  + _Be informed_ of [a number of things](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/individuals-rights/the-right-to-be-informed/)
+  upon provision of their information (either by them or by a 3rd party)
+  such as the legitimate interests of the party collecting the data and the  individual's right to withdraw consent at any time
+  + _Have [access](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/individuals-rights/the-right-of-access/)_
+  to their personal data and how it is being processed **for free**, within one month of requesting it
+  + _Have the 'right to be forgotten'_ and completely [erased](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/individuals-rights/the-right-to-erasure/) from the system
+  + _Have access to their data in a 'portable' form_ , i.e a [machine readable form](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/individuals-rights/the-right-to-data-portability/)
+  such as CSV, within one month of the individual's request for the data
++ [Explicit accountability and transparency](https://github.com/dwyl/ISO-27001-2013-information-technology-security/blob/master/information-security-policy.md) policies & procedures
+are now required (this was implicit in DPA), such as https://github.com/dwyl/ISO-27001-2013-information-technology-security/blob/master/information-security-policy.md
+  + A good start for this is to have a code of conduct (see ['What will codes of conduct address?' section](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/accountability-and-governance/) for more information)
++ Personal data _must_ be **stored inside the EU** (except in [exceptional circumstances](https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/transfer-of-data/))
++ Data _processors_ will now also be held liable for compliance, not just the data
+controllers (who decide what and why personal data is processed)
++ [Privacy Impact Assessments](https://ico.org.uk/media/for-organisations/documents/1595/pia-code-of-practice.pdf) are now mandatory for _certain high risk_ situations (this is still
+  evolving as of the time of writing)
+
+Fines for breaches and non-compliance are _considerably heftier_ than under DPA
+and remember, both [data controllers _and_ data processors](https://www.iabuk.net/policy/briefings/iab-uk-gdpr-checklist#data)
+are now liable under GDPR.
 
 
 ## Recommended Reading

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Also, watch: **10 Things to be Paranoid About as an Entrepreneur**: https://yout
 
 
 
-### Principal of _Least Priviledge_
+### Principal of _Least Privilege_
 
 > "_Every program and every privileged user of the system should operate
 using the **least** amount of **privilege necessary** to complete the job_."
@@ -125,20 +125,33 @@ https://github.com/dwyl/learn-cryptography
 ### OWASP Top 10
 
 The **O**pen **W**eb **A**pplication **S**ecurity **P**roject (OWASP)
-is a great source of information <br />
+is a great source of information <br/>
 about the most common _vulnerabilities_ in web applications/sites. <br />
 see: https://en.wikipedia.org/wiki/OWASP
 
 Rather than _repeat_ the OWASP "Top 10" _here_ we _encourage_ you to
-view the list and _learn_ how each vulnerability on the list can be _mitigated_.
+view the list and _learn_ how each vulnerability on the list can be _mitigated_.**
 
 > Cheat Sheet: https://www.owasp.org/index.php/OWASP_Top_Ten_Cheat_Sheet
 
+## Security Standards
 
-## ISO 27001 ?
+### ISO 27001 ?
 
 If you are interested in the ISO 27001 Information Technology Security standard, <br />
 please see: https://github.com/dwyl/ISO-27001-2013-information-technology-security
+
+### GDPR
+The General Data Protection Regulation (GDPR) is the new EU data protection
+framework that will take over from the UK Data Protection Act 1998 as of
+25th May 2018, for any organisations operating in or offering goods/services to
+the EU.
+
+> [For the UK] The government has confirmed that the UK’s decision to leave the EU will not affect the commencement of the GDPR.
+
+We have read through these and pulled out information _relevant to the kind of
+work that we do at dwyl_ but please see the [Recommended Reading](#recommended-reading)
+section below for resources with further details which may pertain to you.
 
 
 ## Recommended Reading
@@ -161,6 +174,7 @@ http://www.techworld.com/security/uks-most-infamous-data-breaches-2016-3604586/
 https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/521465/Cyber_Security_Breaches_Survey_2016_main_report_FINAL.pdf
 + Calling Humans the “Weakest Link” in Computer Security Is Dangerous and Unhelpful:
 http://www.slate.com/blogs/future_tense/2016/01/22/calling_humans_the_weakest_link_in_computer_security_is_dangerous.html
++ GDPR Overview and Latest Developments: https://ico.org.uk/for-organisations/data-protection-reform/overview-of-the-gdpr/
 
 ## Videos
 


### PR DESCRIPTION
Following a review of ICO and IAB UK's documentation on GDPR for dwyl and our clients, I've added a summary of key points to the readme _and_ restructured it a tiny bit to now have a section on Security Standards, under which both ISO 27001 and GDPR fit.

@nelsonic Could you please review/merge? And close #25 if you think it is now done as a first pass?